### PR TITLE
Add code changes back to the Monitor app

### DIFF
--- a/app/monitor/base.py
+++ b/app/monitor/base.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from datetime import datetime
+import pandas as pd
 
 from bokeh.io import curdoc
 from bokeh.models import ColumnDataSource
@@ -17,6 +18,17 @@ class BaseApp(APIHelper):
         self.doc = curdoc()
         self.args = self.parse_args()
 
+        self.measurements = pd.DataFrame()
+        self.code_changes = pd.DataFrame()
+
+        self.cds = ColumnDataSource(data= {'time': [],
+                                           'date_created': [],
+                                           'value': [],
+                                           'ci_id': [],
+                                           'ci_url': [],
+                                           'count': [],
+                                           'package_names': [],
+                                           'git_urls': []})
     def parse_args(self):
 
         args = self.doc.session_context.request.arguments
@@ -27,21 +39,87 @@ class BaseApp(APIHelper):
 
         return parsed_args
 
-    def load_monitor_data(self, dataset, period):
+    def load_data(self, selected_dataset, selected_metric,
+                  selected_period):
+
+        self.load_measurements(selected_dataset,
+                               selected_metric,
+                               selected_period)
+
+        self.load_code_changes(selected_dataset,
+                               selected_period)
+
+        self.update_datasource()
+
+    def load_code_changes(self, ci_dataset, period):
+
+        self.code_changes = self.get_api_data_as_pandas_df(
+            endpoint='code_changes',
+            params={'ci_dataset': ci_dataset,
+                    'period': period})
+
+    def load_measurements(self, ci_dataset, metric, period):
+
+        self.measurements = self.get_api_data_as_pandas_df(
+            endpoint='monitor',
+            params={'ci_dataset': ci_dataset,
+                    'metric': metric,
+                    'period': period})
+
+        # Add datetime objects from the string representation
+        time = [datetime.strptime(x, "%Y-%m-%dT%H:%M:%SZ")
+                for x in self.measurements['date_created']]
+
+        self.measurements['time'] = time
+
+    @staticmethod
+    def format_package_data(packages):
+
+        package_names = []
+        git_urls = []
+
+        for i, sublist in enumerate(packages):
+            package_names.append([])
+            git_urls.append([])
+            # can be a list or a nan
+            if type(sublist) == list:
+                for package in sublist:
+                    package_names[i].append(package[0])
+                    git_urls[i].append("{}/commit/{}".format(
+                        package[2].replace('.git', ''),
+                        package[1]))
+
+        return package_names, git_urls
+
+    def update_datasource(self):
         """ Create a bokeh column data source for the
         selected dataset and period
         """
-        df = self.get_api_data_as_pandas_df(
-            endpoint='monitor',
-            params={'ci_dataset': dataset, 'period': period})
 
-        self.cds = ColumnDataSource(df)
+        # Use this empty dataframe to reset the column datasource,
+        # column names must match
 
-        # we need the date_created field as python datetime
-        time = [datetime.strptime(x, "%Y-%m-%dT%H:%M:%SZ")
-                for x in df['date_created']]
+        df = pd.DataFrame({'time': [], 'date_created': [],
+                           'value': [], 'ci_id': [], 'ci_url': [],
+                           'packages': [], 'count': [], 'package_names': [],
+                           'git_urls': []})
 
-        self.cds.data['time'] = time
+        if self.measurements.size > 0:
+
+            # Add packages and count columns
+            df = self.measurements.merge(self.code_changes,
+                                         on='ci_id', how='left')
+
+            # Replace NaN with zeros in count
+            df['count'] = df['count'].fillna(0)
+
+            # Add list of package names and git urls
+            package_names, git_urls = self.format_package_data(df['packages'])
+
+            df['package_names'] = package_names
+            df['git_urls'] = git_urls
+
+        self.cds.data = df.to_dict(orient='list')
 
     def set_title(self, title):
         self.doc.title = title

--- a/app/monitor/base.py
+++ b/app/monitor/base.py
@@ -21,14 +21,15 @@ class BaseApp(APIHelper):
         self.measurements = pd.DataFrame()
         self.code_changes = pd.DataFrame()
 
-        self.cds = ColumnDataSource(data= {'time': [],
-                                           'date_created': [],
-                                           'value': [],
-                                           'ci_id': [],
-                                           'ci_url': [],
-                                           'count': [],
-                                           'package_names': [],
-                                           'git_urls': []})
+        self.cds = ColumnDataSource(data={'time': [],
+                                          'date_created': [],
+                                          'value': [],
+                                          'ci_id': [],
+                                          'ci_url': [],
+                                          'count': [],
+                                          'package_names': [],
+                                          'git_urls': []})
+
     def parse_args(self):
 
         args = self.doc.session_context.request.arguments
@@ -98,7 +99,6 @@ class BaseApp(APIHelper):
 
         # Use this empty dataframe to reset the column datasource,
         # column names must match
-
         df = pd.DataFrame({'time': [], 'date_created': [],
                            'value': [], 'ci_id': [], 'ci_url': [],
                            'packages': [], 'count': [], 'package_names': [],

--- a/app/monitor/interactions.py
+++ b/app/monitor/interactions.py
@@ -15,47 +15,57 @@ class Interactions(Layout):
         self.selected_package = new
 
         self.metrics = self.get_metrics(package=self.selected_package)
+        metric_names = self.get_sorted(data=self.metrics, key='name')
+        self.selected_metric = metric_names[0]
 
-        metric_names = self.get_sorted(data=self.metrics,
-                                       key='name')
+        # This will trigger a metric change, and will update the datasource
+        # with measurements for the new selected metric.
+
+        # We can preserve the code changes and the period selection
 
         self.metrics_widget.options = metric_names
 
-        self.selected_metrics = [metric_names[0]]
+        self.load_measurements(self.selected_dataset, self.selected_metric,
+                               self.selected_period)
+
+        self.update_datasource()
 
         self.update_header()
-
-        self.update_tabs()
+        self.update_plot()
+        self.update_footnote()
+        self.update_table()
 
     def on_change_dataset(self, attr, old, new):
 
         self.selected_dataset = new
 
-        self.load_monitor_data(self.selected_dataset, self.selected_period)
+        self.load_data(self.selected_dataset, self.selected_metric,
+                       self.selected_period)
 
-        self.update_header()
-
-        self.update_tabs()
+        self.update_plot()
+        self.update_table()
 
     def on_change_period(self, attr, old, new):
 
         self.selected_period = self.periods['periods'][new]
 
-        self.load_monitor_data(self.selected_dataset, self.selected_period)
+        self.load_data(self.selected_dataset, self.selected_metric,
+                       self.selected_period)
 
-        self.update_tabs()
+        self.update_plot()
+        self.update_table()
 
     def on_change_metric(self, attr, old, new):
 
-        metric = new[0]
+        self.selected_metric = new
 
-        if metric in self.selected_metrics:
-            self.selected_metrics.remove(metric)
-        else:
-            self.selected_metrics.append(metric)
+        # No need to reload code changes here
+        self.load_measurements(self.selected_dataset, self.selected_metric,
+                               self.selected_period)
 
-        # Make sure at least one metric is selected
-        if not self.selected_metrics:
-            self.selected_metrics = [metric]
+        self.update_datasource()
 
-        self.update_tabs()
+        self.update_plot_title()
+        self.update_plot()
+        self.update_footnote()
+        self.update_table()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bokeh==0.12.14
+bokeh==0.12.15
 requests==2.18.4
 pandas==0.20.3
 furl==0.5.7


### PR DESCRIPTION
The monitor app tells a concise story: the impact of code changes on KPMs. My the attempt to expand it to display multiple metrics at once id not work. It does not scale well with the number of metrics (both re loading time and space in the screen). A dashboard-like interface with summary information for the KPMs is be better suited for that.

In this ticket I simplified the monitor implementation and put back the code changes feature.