### PR TITLE
Set SQUASH_BOKEH_APPS in the deployment configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Project specific files
 kubernetes/deployment.yaml
-Dockerfile
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ RUN apt-get update \
 RUN pip install --default-timeout=120 --no-cache-dir -r requirements.txt
 EXPOSE 5006
 # http://bokeh.pydata.org/en/latest/docs/user_guide/server.html#reverse-proxying-with-nginx-and-ssl
-
+WORKDIR /opt/app
 CMD bokeh serve --use-xheaders --allow-websocket-origin=$SQUASH_BOKEH_HOST \
-    --allow-websocket-origin=$SQUASH_DASH_HOST \
-    {{ BOKEH_APPS }} 
+    --allow-websocket-origin=$SQUASH_DASH_HOST $SQUASH_BOKEH_APPS 
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ DEPLOYMENT_CONFIG = kubernetes/deployment.yaml
 SERVICE_CONFIG = kubernetes/service.yaml
 
 build: check-tag check-bokeh-apps
-	sed -e "s|{{ BOKEH_APPS }}|${BOKEH_APPS}|" Dockerfile-template > Dockerfile 
 	docker build -t $(PREFIX):${TAG} .
 
 push: check-tag
@@ -46,4 +45,4 @@ check-tag:
 	@if test -z ${TAG}; then echo "Error: TAG is undefined."; exit 1; fi
 
 check-bokeh-apps:	
-	@if test -z "${BOKEH_APPS}"; then echo "Error: BOKEH_APPS is undefined."; exit 1; fi
+	@if test -z "${SQUASH_BOKEH_APPS}"; then echo "Warning: SQUASH_BOKEH_APPS is undefined, using default in replace.sh"; fi

--- a/README.md
+++ b/README.md
@@ -12,10 +12,17 @@ The SQuaSH Bokeh serves the squash-bokeh apps, we use the Bokeh plotting library
 Assuming you have kubectl configured to access your GCE cluster, you can deploy `squash-bokeh` using:
 
 ```
-export BOKEH_APPS="app/code_changes app/AMx" # list of bokeh apps you want to deploy
-export TAG=latest 
-make build push deployment
+TAG=latest make deployment
 ```
+
+NOTE: the bokeh apps to be deployed can be configured by setting the following variable:
+```
+export SQUASH_BOKEH_APPS="code_changes AMx"
+```
+the default is to deploy all the bokeh apps in the `/app` folder. 
+
+Also, it must be consistent with the bokeh apps configured in the [squash](https://github.com/lsst-sqre/squash) deployment.
+
 
 ### Debugging
 

--- a/kubernetes/deployment-template.yaml
+++ b/kubernetes/deployment-template.yaml
@@ -37,6 +37,8 @@ spec:
               value: {{ SQUASH_BOKEH_HOST }}
             - name: SQUASH_API_URL
               value: {{ SQUASH_API_URL }}
+            - name: SQUASH_BOKEH_APPS
+              value: {{ SQUASH_BOKEH_APPS }}
       volumes:
         - name: tls-certs
           secret:

--- a/kubernetes/replace.sh
+++ b/kubernetes/replace.sh
@@ -48,9 +48,14 @@ if [ "$NAMESPACE" == "squash-prod" ]; then
     SQUASH_API_URL="https://squash-restful-api.lsst.codes"
 fi
 
+if [ -z "$SQUASH_BOKEH_APPS" ]; then
+    SQUASH_BOKEH_APPS="monitor code_changes AMx"
+fi
+
 sed -e "
 s/{{ TAG }}/${TAG}/
 s/{{ SQUASH_DASH_HOST }}/${SQUASH_DASH_HOST}/
 s/{{ SQUASH_BOKEH_HOST }}/${SQUASH_BOKEH_HOST}/
 s|{{ SQUASH_API_URL }}|\"${SQUASH_API_URL}\"|
+s|{{ SQUASH_BOKEH_APPS }}|\"${SQUASH_BOKEH_APPS}\"|
 " $1 > $2


### PR DESCRIPTION
- the bokeh apps to deploy can be configured by setting the `SQUASH_BOKEH_APPS` variable. The default behaviour is to deploy all the bokeh apps in the `/app` folder. 