### PR TITLE
[DM-14376] Display TE1 and TE2 metrics in more appropriate units in SQuaSH

### DIFF
--- a/app/code_changes/base.py
+++ b/app/code_changes/base.py
@@ -20,9 +20,9 @@ class BaseApp(APIHelper):
         self.message = str()
 
         self.empty = {'job_id': [], 'time': [], 'date_created': [],
-                      'value': [], 'ci_id': [], 'ci_url': [], 'count': [],
-                      'filter_name': [], 'color': [], 'package_names': [],
-                      'git_urls': []}
+                      'value': [], 'formatted_value': [], 'ci_id': [],
+                      'ci_url': [], 'count': [], 'filter_name': [],
+                      'color': [], 'package_names': [], 'git_urls': []}
 
         self.cds = ColumnDataSource(data=self.empty)
 
@@ -147,6 +147,13 @@ class BaseApp(APIHelper):
         color = []
         for filter_name in self.measurements['filter_name']:
             color.append(self.get_filter_color(filter_name))
+
+        # DM-14376
+        # for displaying the five most significant digits
+        formatted_value = ["{0:.5g}".format(value)
+                           for value in self.measurements['value']]
+
+        self.measurements['formatted_value'] = formatted_value
 
         self.measurements['color'] = color
 

--- a/app/code_changes/layout.py
+++ b/app/code_changes/layout.py
@@ -230,15 +230,15 @@ class Layout(BaseApp):
 
             # Drill down app, it uses the job_id to access the data blobs
             app_url = "/dash/AMx?job_id=<%= job_id %>" \
-                     "&metric={}&ci_id=<%= ci_id %>" \
-                     "&ci_dataset={}".format(self.selected_metric,
-                                             self.selected_dataset)
+                      "&metric={}&ci_id=<%= ci_id %>" \
+                      "&ci_dataset={}".format(self.selected_metric,
+                                              self.selected_dataset)
 
-            template = '<a href="{}" ><%= parseFloat(value).toFixed(3) %>' \
+            template = '<a href="{}" ><%= formatted_value %>' \
                        '</a>'.format(app_url)
 
         else:
-            template = "<%= parseFloat(value).toFixed(3) %>"
+            template = "<%= formatted_value %>"
 
         # https://squash-restful-api-demo.lsst.codes/AMx?job_id=885
         # &metric=validate_drp.AM1


### PR DESCRIPTION
Added a new column in the Bokeh datasource to keep formatted metric values with four significant digits for display.